### PR TITLE
Check for valid JSON in API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,7 @@
 
 - Fix misnamed env var in client instantiation
 - Add a sample `.env` file
+
+## [0.0.7] - 2021-03-12
+
+- Check for valid JSON from API response before continuing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dev_orbit (0.0.4)
+    dev_orbit (0.0.6)
       actionview (~> 6.1)
       activesupport (~> 6.1)
       http (~> 4.4)
@@ -59,7 +59,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     minitest (5.14.4)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.0.0)

--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "json"
 require "active_support/time"
+require_relative "utils"
 
 module DevOrbit
   class Dev
@@ -18,6 +19,7 @@ module DevOrbit
 
       articles.each do |article|
         comments = get_article_comments(article["id"])
+
         next if comments.empty?
 
         DevOrbit::Orbit.call(
@@ -44,9 +46,7 @@ module DevOrbit
 
       response = https.request(request)
 
-      puts "Get articles response: #{response.body}"
-
-      JSON.parse(response.body)
+      JSON.parse(response.body) if DevOrbit::Utils.valid_json?(response.body)
     end
 
     def get_article_comments(id)
@@ -57,7 +57,8 @@ module DevOrbit
       request = Net::HTTP::Get.new(url)
 
       response = https.request(request)
-      comments = JSON.parse(response.body)
+
+      comments = JSON.parse(response.body) if DevOrbit::Utils.valid_json?(response.body)
 
       filter_comments(comments)
     end

--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -44,6 +44,8 @@ module DevOrbit
 
       response = https.request(request)
 
+      puts "Get articles response: #{response.body}"
+
       JSON.parse(response.body)
     end
 

--- a/lib/dev_orbit/interactions/comment.rb
+++ b/lib/dev_orbit/interactions/comment.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "json"
 require "action_view"
+require_relative "../utils"
 
 module DevOrbit
   module Interactions
@@ -36,9 +37,7 @@ module DevOrbit
 
         response = http.request(req)
 
-        puts "New activity Orbit API call response body: #{response.body}"
-
-        JSON.parse(response.body)
+        JSON.parse(response.body) if DevOrbit::Utils.valid_json?(response.body)
       end
 
       def construct_body

--- a/lib/dev_orbit/interactions/comment.rb
+++ b/lib/dev_orbit/interactions/comment.rb
@@ -36,7 +36,9 @@ module DevOrbit
 
         response = http.request(req)
 
-        puts JSON.parse(response.body)
+        puts "New activity Orbit API call response body: #{response.body}"
+
+        JSON.parse(response.body)
       end
 
       def construct_body

--- a/lib/dev_orbit/utils.rb
+++ b/lib/dev_orbit/utils.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DevOrbit
+  class Utils
+    def self.valid_json?(string)
+      !JSON.parse(string).nil?
+    rescue JSON::ParserError
+      false
+    end
+  end
+end

--- a/lib/dev_orbit/version.rb
+++ b/lib/dev_orbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevOrbit
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
Sometimes one of the two APIs (DEV or Orbit) returns an error response for maintenance reasons, and the gem was not handling it properly when the response was not in correct JSON format. This checks for valid JSON before attempting to parse it.