### PR TITLE
fix empty comments error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,7 @@
 ## [0.0.7] - 2021-03-12
 
 - Check for valid JSON from API response before continuing
+
+## [0.0.8] - 2021-03-16
+
+- Early return if there are no new comments

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dev_orbit (0.0.6)
+    dev_orbit (0.0.7)
       actionview (~> 6.1)
       activesupport (~> 6.1)
       http (~> 4.4)

--- a/lib/dev_orbit/dev.rb
+++ b/lib/dev_orbit/dev.rb
@@ -20,7 +20,7 @@ module DevOrbit
       articles.each do |article|
         comments = get_article_comments(article["id"])
 
-        next if comments.empty?
+        next if comments.nil? || comments.empty?
 
         DevOrbit::Orbit.call(
           type: "comments",
@@ -59,6 +59,8 @@ module DevOrbit
       response = https.request(request)
 
       comments = JSON.parse(response.body) if DevOrbit::Utils.valid_json?(response.body)
+
+      return if comments.nil? || comments.empty?
 
       filter_comments(comments)
     end

--- a/lib/dev_orbit/version.rb
+++ b/lib/dev_orbit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DevOrbit
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
If there were no comments then an error was raised when `#filter_comments` was invoked. This PR fixes it by causing an early return if the comments are nil or empty.